### PR TITLE
feat: add crate-level [deny] config to .capsec.toml

### DIFF
--- a/crates/capsec-tests/tests/audit_evasion.rs
+++ b/crates/capsec-tests/tests/audit_evasion.rs
@@ -11,7 +11,7 @@ use cargo_capsec::parser::parse_source;
 fn count_findings(source: &str) -> usize {
     let parsed = parse_source(source, "evasion_test.rs").unwrap();
     let detector = Detector::new();
-    detector.analyse(&parsed, "test-crate", "0.1.0").len()
+    detector.analyse(&parsed, "test-crate", "0.1.0", &[]).len()
 }
 
 /// Helper: returns true if the source evades detection (zero findings).

--- a/crates/cargo-capsec/src/config.rs
+++ b/crates/cargo-capsec/src/config.rs
@@ -7,10 +7,14 @@
 //!   internal RPC, secret fetchers) that the built-in registry doesn't cover.
 //! - **Allow rules** — suppress known-good findings by crate name and/or function name.
 //! - **Exclude patterns** — skip files matching glob patterns (tests, benches, generated code).
+//! - **Deny rules** — treat all ambient authority in matching categories as Critical deny violations.
 //!
 //! # Example
 //!
 //! ```toml
+//! [deny]
+//! categories = ["all"]
+//!
 //! [analysis]
 //! exclude = ["tests/**", "benches/**"]
 //!
@@ -34,15 +38,30 @@ const CONFIG_FILE: &str = ".capsec.toml";
 /// Top-level configuration loaded from `.capsec.toml`.
 ///
 /// All fields are optional — a missing config file produces sensible defaults
-/// (no excludes, no custom authorities, no allow rules).
+/// (no excludes, no custom authorities, no allow rules, no deny rules).
 #[derive(Debug, Deserialize, Default)]
 pub struct Config {
+    #[serde(default)]
+    pub deny: DenyConfig,
     #[serde(default)]
     pub analysis: AnalysisConfig,
     #[serde(default)]
     pub authority: Vec<AuthorityEntry>,
     #[serde(default)]
     pub allow: Vec<AllowEntry>,
+}
+
+/// Crate-level deny configuration from `[deny]` in `.capsec.toml`.
+///
+/// When categories are specified, any ambient authority matching those categories
+/// is promoted to a Critical-risk deny violation — the same behavior as
+/// `#[capsec::deny(...)]` on individual functions, but applied crate-wide.
+///
+/// Valid categories: `all`, `fs`, `net`, `env`, `process`, `ffi`.
+#[derive(Debug, Deserialize, Default)]
+pub struct DenyConfig {
+    #[serde(default)]
+    pub categories: Vec<String>,
 }
 
 /// Settings that control which files are scanned.
@@ -86,6 +105,26 @@ impl AllowEntry {
     /// Returns the crate name from either `crate` or `crate_name` key.
     pub fn effective_crate(&self) -> Option<&str> {
         self.crate_name.as_deref().or(self.crate_key.as_deref())
+    }
+}
+
+const VALID_DENY_CATEGORIES: &[&str] = &["all", "fs", "net", "env", "process", "ffi"];
+
+impl DenyConfig {
+    /// Normalizes category names to lowercase and warns about unknown categories.
+    pub fn normalized_categories(&self) -> Vec<String> {
+        self.categories
+            .iter()
+            .filter_map(|cat| {
+                let lower = cat.to_lowercase();
+                if VALID_DENY_CATEGORIES.contains(&lower.as_str()) {
+                    Some(lower)
+                } else {
+                    eprintln!("Warning: unknown deny category '{cat}', ignoring (valid: all, fs, net, env, process, ffi)");
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -209,6 +248,45 @@ mod tests {
         let config = load_config(Path::new("/nonexistent/path"), &cap).unwrap();
         assert!(config.authority.is_empty());
         assert!(config.allow.is_empty());
+    }
+
+    #[test]
+    fn parse_deny_config() {
+        let toml = r#"
+            [deny]
+            categories = ["all"]
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.deny.categories, vec!["all"]);
+    }
+
+    #[test]
+    fn parse_deny_selective_categories() {
+        let toml = r#"
+            [deny]
+            categories = ["fs", "net"]
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.deny.categories, vec!["fs", "net"]);
+    }
+
+    #[test]
+    fn missing_deny_section_defaults_to_empty() {
+        let toml = r#"
+            [[allow]]
+            crate = "tracing"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.deny.categories.is_empty());
+    }
+
+    #[test]
+    fn normalized_categories_lowercases_and_filters() {
+        let deny = DenyConfig {
+            categories: vec!["FS".to_string(), "bogus".to_string(), "net".to_string()],
+        };
+        let normalized = deny.normalized_categories();
+        assert_eq!(normalized, vec!["fs", "net"]);
     }
 
     #[test]

--- a/crates/cargo-capsec/src/detector.rs
+++ b/crates/cargo-capsec/src/detector.rs
@@ -88,7 +88,7 @@ pub struct Finding {
 ///
 /// let parsed = parse_source(source, "example.rs").unwrap();
 /// let detector = Detector::new();
-/// let findings = detector.analyse(&parsed, "my-crate", "0.1.0");
+/// let findings = detector.analyse(&parsed, "my-crate", "0.1.0", &[]);
 /// assert_eq!(findings.len(), 1);
 /// ```
 pub struct Detector {
@@ -127,16 +127,23 @@ impl Detector {
     ///
     /// Expands call paths using the file's `use` imports, matches against the
     /// authority registry (built-in + custom), and deduplicates by call site.
+    ///
+    /// `crate_deny` is the list of denied categories from `.capsec.toml`'s `[deny]`
+    /// section. These are merged with any function-level `#[capsec::deny(...)]`
+    /// annotations (union semantics).
     pub fn analyse(
         &self,
         file: &ParsedFile,
         crate_name: &str,
         crate_version: &str,
+        crate_deny: &[String],
     ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let (import_map, glob_prefixes) = build_import_map(&file.use_imports);
 
         for func in &file.functions {
+            let effective_deny = merge_deny(&func.deny_categories, crate_deny);
+
             // Expand all calls upfront for context lookups
             let expanded_calls: Vec<Vec<String>> = func
                 .calls
@@ -173,6 +180,7 @@ impl Detector {
                             authority,
                             crate_name,
                             crate_version,
+                            &effective_deny,
                         ));
                         break;
                     }
@@ -181,7 +189,7 @@ impl Detector {
                 // Custom path authorities
                 for (pattern, category, risk, description) in &self.custom_paths {
                     if matches_custom_path(expanded, pattern) {
-                        let deny_violation = is_category_denied(&func.deny_categories, category);
+                        let deny_violation = is_category_denied(&effective_deny, category);
                         findings.push(Finding {
                             file: file.path.clone(),
                             function: func.name.clone(),
@@ -232,6 +240,7 @@ impl Detector {
                                 authority,
                                 crate_name,
                                 crate_version,
+                                &effective_deny,
                             ));
                             break;
                         }
@@ -240,8 +249,9 @@ impl Detector {
             }
         }
 
-        // Extern blocks (not inside a function, so no deny context)
+        // Extern blocks — check crate-level deny for FFI category
         for ext in &file.extern_blocks {
+            let deny_violation = is_category_denied(crate_deny, &Category::Ffi);
             findings.push(Finding {
                 file: file.path.clone(),
                 function: format!("extern \"{}\"", ext.abi.as_deref().unwrap_or("C")),
@@ -255,12 +265,20 @@ impl Detector {
                 ),
                 category: Category::Ffi,
                 subcategory: "extern".to_string(),
-                risk: Risk::High,
-                description: "Foreign function interface — bypasses Rust safety".to_string(),
+                risk: if deny_violation {
+                    Risk::Critical
+                } else {
+                    Risk::High
+                },
+                description: if deny_violation {
+                    "DENY VIOLATION: Foreign function interface — bypasses Rust safety".to_string()
+                } else {
+                    "Foreign function interface — bypasses Rust safety".to_string()
+                },
                 is_build_script: file.path.ends_with("build.rs"),
                 crate_name: crate_name.to_string(),
                 crate_version: crate_version.to_string(),
-                is_deny_violation: false,
+                is_deny_violation: deny_violation,
             });
         }
 
@@ -273,6 +291,7 @@ impl Detector {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn make_finding(
     file: &ParsedFile,
     func: &crate::parser::ParsedFunction,
@@ -281,8 +300,9 @@ fn make_finding(
     authority: &Authority,
     crate_name: &str,
     crate_version: &str,
+    effective_deny: &[String],
 ) -> Finding {
-    let is_deny_violation = is_category_denied(&func.deny_categories, &authority.category);
+    let is_deny_violation = is_category_denied(effective_deny, &authority.category);
     Finding {
         file: file.path.clone(),
         function: func.name.clone(),
@@ -312,7 +332,24 @@ fn make_finding(
     }
 }
 
-/// Checks if a finding's category is covered by the function's deny list.
+/// Merges function-level and crate-level deny categories (union semantics).
+fn merge_deny(function_deny: &[String], crate_deny: &[String]) -> Vec<String> {
+    if crate_deny.is_empty() {
+        return function_deny.to_vec();
+    }
+    if function_deny.is_empty() {
+        return crate_deny.to_vec();
+    }
+    let mut merged = function_deny.to_vec();
+    for cat in crate_deny {
+        if !merged.contains(cat) {
+            merged.push(cat.clone());
+        }
+    }
+    merged
+}
+
+/// Checks if a finding's category is covered by the deny list.
 fn is_category_denied(deny_categories: &[String], finding_category: &Category) -> bool {
     if deny_categories.is_empty() {
         return false;
@@ -429,7 +466,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(!findings.is_empty());
         assert_eq!(findings[0].category, Category::Fs);
     }
@@ -444,7 +481,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(!findings.is_empty());
         assert_eq!(findings[0].category, Category::Fs);
         assert!(findings[0].call_text.contains("read_to_string"));
@@ -461,7 +498,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         let proc_findings: Vec<_> = findings
             .iter()
             .filter(|f| f.category == Category::Process)
@@ -484,7 +521,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         let proc_findings: Vec<_> = findings
             .iter()
             .filter(|f| f.category == Category::Process)
@@ -504,7 +541,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].category, Category::Ffi);
     }
@@ -516,7 +553,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(findings.is_empty());
     }
 
@@ -530,7 +567,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(!findings.is_empty());
         assert_eq!(findings[0].category, Category::Process);
         assert_eq!(findings[0].risk, Risk::Critical);
@@ -548,7 +585,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         // Each unique (file, function, line, col) should appear at most once
         let mut seen = std::collections::HashSet::new();
         for f in &findings {
@@ -572,7 +609,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(!findings.is_empty());
         assert!(findings[0].is_deny_violation);
         assert_eq!(findings[0].risk, Risk::Critical);
@@ -592,7 +629,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         let fs_findings: Vec<_> = findings
             .iter()
             .filter(|f| f.category == Category::Fs)
@@ -616,7 +653,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(!findings.is_empty());
         assert!(!findings[0].is_deny_violation);
     }
@@ -631,7 +668,7 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(
             !findings.is_empty(),
             "Should detect aliased import: use std::fs::read as load"
@@ -653,11 +690,115 @@ mod tests {
         "#;
         let parsed = parse_source(source, "test.rs").unwrap();
         let detector = Detector::new();
-        let findings = detector.analyse(&parsed, "test-crate", "0.1.0");
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
         assert!(
             !findings.is_empty(),
             "Should detect fs::read inside impl block"
         );
         assert_eq!(findings[0].function, "load");
+    }
+
+    #[test]
+    fn crate_deny_all_flags_everything() {
+        let source = r#"
+            use std::fs;
+            fn normal() {
+                let _ = fs::read("data");
+            }
+        "#;
+        let parsed = parse_source(source, "test.rs").unwrap();
+        let detector = Detector::new();
+        let crate_deny = vec!["all".to_string()];
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &crate_deny);
+        assert!(!findings.is_empty());
+        assert!(findings[0].is_deny_violation);
+        assert_eq!(findings[0].risk, Risk::Critical);
+        assert!(findings[0].description.contains("DENY VIOLATION"));
+    }
+
+    #[test]
+    fn crate_deny_fs_only_flags_fs() {
+        let source = r#"
+            use std::fs;
+            use std::net::TcpStream;
+            fn mixed() {
+                let _ = fs::read("data");
+                let _ = TcpStream::connect("127.0.0.1:80");
+            }
+        "#;
+        let parsed = parse_source(source, "test.rs").unwrap();
+        let detector = Detector::new();
+        let crate_deny = vec!["fs".to_string()];
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &crate_deny);
+        let fs_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.category == Category::Fs)
+            .collect();
+        let net_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.category == Category::Net)
+            .collect();
+        assert!(fs_findings[0].is_deny_violation);
+        assert_eq!(fs_findings[0].risk, Risk::Critical);
+        assert!(!net_findings[0].is_deny_violation);
+    }
+
+    #[test]
+    fn crate_deny_merges_with_function_deny() {
+        let source = r#"
+            use std::fs;
+            use std::net::TcpStream;
+            #[doc = "capsec::deny(net)"]
+            fn mixed() {
+                let _ = fs::read("data");
+                let _ = TcpStream::connect("127.0.0.1:80");
+            }
+        "#;
+        let parsed = parse_source(source, "test.rs").unwrap();
+        let detector = Detector::new();
+        let crate_deny = vec!["fs".to_string()];
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &crate_deny);
+        let fs_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.category == Category::Fs)
+            .collect();
+        let net_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.category == Category::Net)
+            .collect();
+        // Both should be deny violations: fs from crate-level, net from function-level
+        assert!(fs_findings[0].is_deny_violation);
+        assert!(net_findings[0].is_deny_violation);
+    }
+
+    #[test]
+    fn crate_deny_flags_extern_blocks() {
+        let source = r#"
+            extern "C" {
+                fn open(path: *const u8, flags: i32) -> i32;
+            }
+        "#;
+        let parsed = parse_source(source, "test.rs").unwrap();
+        let detector = Detector::new();
+        let crate_deny = vec!["all".to_string()];
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &crate_deny);
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].is_deny_violation);
+        assert_eq!(findings[0].risk, Risk::Critical);
+    }
+
+    #[test]
+    fn empty_crate_deny_no_regression() {
+        let source = r#"
+            use std::fs;
+            fn normal() {
+                let _ = fs::read("data");
+            }
+        "#;
+        let parsed = parse_source(source, "test.rs").unwrap();
+        let detector = Detector::new();
+        let findings = detector.analyse(&parsed, "test-crate", "0.1.0", &[]);
+        assert!(!findings.is_empty());
+        assert!(!findings[0].is_deny_violation);
     }
 }

--- a/crates/cargo-capsec/src/lib.rs
+++ b/crates/cargo-capsec/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! Supporting modules:
 //!
-//! - **[`config`]** — `.capsec.toml` parsing for custom authorities and allow rules
+//! - **[`config`]** — `.capsec.toml` parsing for custom authorities, allow rules, and crate-level deny
 //! - **[`baseline`]** — diff findings against previous runs to detect new capabilities
 //!
 //! ## Programmatic usage
@@ -35,7 +35,7 @@
 //!
 //! let parsed = parse_source(source, "example.rs").unwrap();
 //! let detector = Detector::new();
-//! let findings = detector.analyse(&parsed, "my-crate", "0.1.0");
+//! let findings = detector.analyse(&parsed, "my-crate", "0.1.0", &[]);
 //!
 //! for f in &findings {
 //!     println!("[{}] {} in {}()", f.category.label(), f.call_text, f.function);

--- a/crates/cargo-capsec/src/main.rs
+++ b/crates/cargo-capsec/src/main.rs
@@ -78,6 +78,7 @@ fn run_audit(args: AuditArgs) {
     let mut det = detector::Detector::new();
     let customs = config::custom_authorities(&cfg);
     det.add_custom_authorities(&customs);
+    let crate_deny = cfg.deny.normalized_categories();
 
     // Parse and detect
     let mut all_findings = Vec::new();
@@ -92,7 +93,7 @@ fn run_audit(args: AuditArgs) {
 
             match parser::parse_file(&file_path, &fs_read) {
                 Ok(parsed) => {
-                    let findings = det.analyse(&parsed, &krate.name, &krate.version);
+                    let findings = det.analyse(&parsed, &krate.name, &krate.version, &crate_deny);
                     all_findings.extend(findings);
                 }
                 Err(e) => {
@@ -180,6 +181,15 @@ fn run_check_deny(args: CheckDenyArgs) {
 
     let path_arg = args.path.canonicalize().unwrap_or(args.path.clone());
 
+    // Load config
+    let cfg = match config::load_config(&path_arg, &fs_read) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Warning: {e}");
+            config::Config::default()
+        }
+    };
+
     // Discover crates
     let discovery = match discovery::discover_crates(&path_arg, false, &spawn_cap, &fs_read) {
         Ok(d) => d,
@@ -211,8 +221,11 @@ fn run_check_deny(args: CheckDenyArgs) {
         })
         .collect();
 
-    // Set up detector
-    let det = detector::Detector::new();
+    // Set up detector with custom authorities
+    let mut det = detector::Detector::new();
+    let customs = config::custom_authorities(&cfg);
+    det.add_custom_authorities(&customs);
+    let crate_deny = cfg.deny.normalized_categories();
 
     // Parse, detect, and filter to deny violations only
     let mut violations = Vec::new();
@@ -223,7 +236,7 @@ fn run_check_deny(args: CheckDenyArgs) {
         for file_path in source_files {
             match parser::parse_file(&file_path, &fs_read) {
                 Ok(parsed) => {
-                    let findings = det.analyse(&parsed, &krate.name, &krate.version);
+                    let findings = det.analyse(&parsed, &krate.name, &krate.version, &crate_deny);
                     violations.extend(findings.into_iter().filter(|f| f.is_deny_violation).map(
                         |mut f| {
                             f.file = make_relative(&f.file, &workspace_root);
@@ -239,7 +252,14 @@ fn run_check_deny(args: CheckDenyArgs) {
     }
 
     if violations.is_empty() {
-        println!("OK  All #[capsec::deny] annotations are respected.");
+        if crate_deny.is_empty() {
+            println!("OK  All #[capsec::deny] annotations are respected.");
+        } else {
+            println!(
+                "OK  All deny rules are respected (crate-level: [{}])",
+                crate_deny.join(", ")
+            );
+        }
         return;
     }
 
@@ -314,6 +334,7 @@ fn run_badge(args: BadgeArgs) {
     let mut det = detector::Detector::new();
     let customs = config::custom_authorities(&cfg);
     det.add_custom_authorities(&customs);
+    let crate_deny = cfg.deny.normalized_categories();
 
     let mut all_findings = Vec::new();
     for krate in &crates {
@@ -326,7 +347,7 @@ fn run_badge(args: BadgeArgs) {
                 continue;
             }
             if let Ok(parsed) = parser::parse_file(&file_path, &fs_read) {
-                let findings = det.analyse(&parsed, &krate.name, &krate.version);
+                let findings = det.analyse(&parsed, &krate.name, &krate.version, &crate_deny);
                 all_findings.extend(findings);
             }
         }

--- a/crates/cargo-capsec/tests/integration.rs
+++ b/crates/cargo-capsec/tests/integration.rs
@@ -19,7 +19,7 @@ fn clean_crate_zero_findings() {
     let source = fixture_source("clean_crate");
     let parsed = parse_source(&source, "clean_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "clean_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "clean_crate", "0.1.0", &[]);
     assert!(
         findings.is_empty(),
         "Clean crate should have zero findings, got: {findings:?}"
@@ -31,7 +31,7 @@ fn fs_crate_detects_filesystem_calls() {
     let source = fixture_source("fs_crate");
     let parsed = parse_source(&source, "fs_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "fs_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "fs_crate", "0.1.0", &[]);
 
     let fs_findings: Vec<_> = findings
         .iter()
@@ -76,7 +76,7 @@ fn net_crate_detects_network_calls() {
     let source = fixture_source("net_crate");
     let parsed = parse_source(&source, "net_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "net_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "net_crate", "0.1.0", &[]);
 
     let net_findings: Vec<_> = findings
         .iter()
@@ -104,7 +104,7 @@ fn sneaky_crate_detects_imported_calls() {
     let source = fixture_source("sneaky_crate");
     let parsed = parse_source(&source, "sneaky_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "sneaky_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "sneaky_crate", "0.1.0", &[]);
 
     // Should detect read_to_string via import expansion
     let fs_findings: Vec<_> = findings
@@ -133,7 +133,7 @@ fn aliased_crate_detects_renamed_imports() {
     let source = fixture_source("aliased_crate");
     let parsed = parse_source(&source, "aliased_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "aliased_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "aliased_crate", "0.1.0", &[]);
 
     // Import aliases ARE detected because we track use-statement aliases
     assert!(
@@ -156,7 +156,7 @@ fn json_output_is_valid() {
     let source = fixture_source("fs_crate");
     let parsed = parse_source(&source, "fs_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "fs_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "fs_crate", "0.1.0", &[]);
 
     let json = cargo_capsec::reporter::report_json(&findings);
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -168,7 +168,7 @@ fn sarif_output_is_valid() {
     let source = fixture_source("fs_crate");
     let parsed = parse_source(&source, "fs_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "fs_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "fs_crate", "0.1.0", &[]);
 
     let sarif = cargo_capsec::reporter::report_sarif(&findings, std::path::Path::new("."));
     let parsed: serde_json::Value = serde_json::from_str(&sarif).unwrap();
@@ -181,7 +181,7 @@ fn config_allow_suppresses_findings() {
     let source = fixture_source("fs_crate");
     let parsed = parse_source(&source, "fs_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let mut findings = detector.analyse(&parsed, "fs_crate", "0.1.0");
+    let mut findings = detector.analyse(&parsed, "fs_crate", "0.1.0", &[]);
 
     let toml_str = r#"
         [[allow]]
@@ -204,7 +204,7 @@ fn baseline_round_trip() {
     let source = fixture_source("net_crate");
     let parsed = parse_source(&source, "net_crate/src/lib.rs").unwrap();
     let detector = Detector::new();
-    let findings = detector.analyse(&parsed, "net_crate", "0.1.0");
+    let findings = detector.analyse(&parsed, "net_crate", "0.1.0", &[]);
 
     let root = capsec_core::root::test_root();
     let read_cap = root.grant::<capsec_core::permission::FsRead>();


### PR DESCRIPTION
Users can now declare denied categories at the crate level via config instead of annotating every function with #[capsec::deny(...)]:

   [deny]
   categories = ["all"]   # or ["fs", "net"], etc.

Any ambient authority matching a denied category is promoted to a Critical-risk deny violation, same as function-level deny but applied crate-wide. Function-level and crate-level deny use union semantics.