### PR TITLE
feat: add capability prescripts — LoggedCap (audit trail) and DualKey

### DIFF
--- a/crates/capsec-core/src/error.rs
+++ b/crates/capsec-core/src/error.rs
@@ -29,4 +29,8 @@ pub enum CapSecError {
     /// The capability has expired (TTL elapsed).
     #[error("capability has expired")]
     Expired,
+
+    /// The capability requires multiple approvals, but not all have been granted.
+    #[error("capability requires dual-key approval, but approvals are insufficient")]
+    InsufficientApprovals,
 }

--- a/crates/capsec-core/src/lib.rs
+++ b/crates/capsec-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod cap;
 pub mod error;
 pub mod has;
 pub mod permission;
+pub mod prescript;
 pub mod root;
 pub mod runtime;
 

--- a/crates/capsec-core/src/prescript.rs
+++ b/crates/capsec-core/src/prescript.rs
@@ -1,0 +1,559 @@
+//! Capability prescripts: audit-trail and dual-authorization wrappers.
+//!
+//! [`LoggedCap<P>`] wraps a [`Cap<P>`](crate::cap::Cap) with an append-only audit log
+//! that records every [`try_cap()`](LoggedCap::try_cap) invocation.
+//! [`DualKeyCap<P>`] wraps a `Cap<P>` with a dual-authorization gate that requires
+//! two independent approvals before [`try_cap()`](DualKeyCap::try_cap) succeeds.
+//!
+//! Neither type implements [`Has<P>`](crate::has::Has) — callers must use `try_cap()`
+//! and handle the fallible result explicitly.
+//!
+//! These types implement Saltzer & Schroeder's "prescript" concept — actions
+//! triggered before capability exercise — specifically Design Principle #5
+//! (Separation of Privilege) and #8 (Compromise Recording).
+
+use crate::cap::Cap;
+use crate::error::CapSecError;
+use crate::permission::Permission;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+// ============================================================================
+// LogEntry
+// ============================================================================
+
+/// A record of a single capability exercise attempt.
+///
+/// Created automatically by [`LoggedCap::try_cap`] and stored in the
+/// shared audit log.
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    /// Monotonic timestamp of the exercise attempt.
+    pub timestamp: Instant,
+    /// The permission type name (via [`std::any::type_name`]).
+    pub permission: &'static str,
+    /// Whether the capability was granted (`true`) or denied (`false`).
+    pub granted: bool,
+}
+
+// ============================================================================
+// LoggedCap<P>
+// ============================================================================
+
+/// An audited capability token that logs every exercise attempt.
+///
+/// Created via [`LoggedCap::new`], which consumes a [`Cap<P>`] as proof of
+/// possession. Every call to [`try_cap`](LoggedCap::try_cap) appends a
+/// [`LogEntry`] to the shared audit log.
+///
+/// `!Send + !Sync` by default — use [`make_send`](LoggedCap::make_send) for
+/// cross-thread transfer. Cloning shares the same audit log: entries from
+/// any clone appear in the same log.
+pub struct LoggedCap<P: Permission> {
+    _phantom: PhantomData<P>,
+    _not_send: PhantomData<*const ()>,
+    log: Arc<Mutex<Vec<LogEntry>>>,
+}
+
+impl<P: Permission> LoggedCap<P> {
+    /// Creates an audited capability by consuming a [`Cap<P>`] as proof of possession.
+    pub fn new(_cap: Cap<P>) -> Self {
+        Self {
+            _phantom: PhantomData,
+            _not_send: PhantomData,
+            log: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Attempts to obtain a [`Cap<P>`] and records the attempt in the audit log.
+    ///
+    /// Always succeeds (since `LoggedCap` wraps a `Cap<P>` directly). The
+    /// `granted` field in the log entry is always `true`.
+    pub fn try_cap(&self) -> Result<Cap<P>, CapSecError> {
+        let entry = LogEntry {
+            timestamp: Instant::now(),
+            permission: std::any::type_name::<P>(),
+            granted: true,
+        };
+        let mut log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        log.push(entry);
+        Ok(Cap::new())
+    }
+
+    /// Advisory check — always returns `true` for `LoggedCap`.
+    pub fn is_active(&self) -> bool {
+        true
+    }
+
+    /// Returns a cloned snapshot of the audit log.
+    pub fn entries(&self) -> Vec<LogEntry> {
+        let log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        log.clone()
+    }
+
+    /// Returns the number of entries in the audit log.
+    pub fn entry_count(&self) -> usize {
+        let log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        log.len()
+    }
+
+    /// Converts this capability into a [`LoggedSendCap`] that can cross thread boundaries.
+    pub fn make_send(self) -> LoggedSendCap<P> {
+        LoggedSendCap {
+            _phantom: PhantomData,
+            log: self.log,
+        }
+    }
+}
+
+impl<P: Permission> Clone for LoggedCap<P> {
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: PhantomData,
+            _not_send: PhantomData,
+            log: Arc::clone(&self.log),
+        }
+    }
+}
+
+// ============================================================================
+// LoggedSendCap<P>
+// ============================================================================
+
+/// A thread-safe audited capability token.
+///
+/// Created via [`LoggedCap::make_send`]. Unlike [`LoggedCap`], this implements
+/// `Send + Sync`, making it usable with `std::thread::spawn`, `tokio::spawn`, etc.
+pub struct LoggedSendCap<P: Permission> {
+    _phantom: PhantomData<P>,
+    log: Arc<Mutex<Vec<LogEntry>>>,
+}
+
+// SAFETY: LoggedSendCap is explicitly opted into cross-thread transfer via make_send().
+// The inner Arc<Mutex<Vec<LogEntry>>> is already Send+Sync.
+unsafe impl<P: Permission> Send for LoggedSendCap<P> {}
+unsafe impl<P: Permission> Sync for LoggedSendCap<P> {}
+
+impl<P: Permission> LoggedSendCap<P> {
+    /// Attempts to obtain a [`Cap<P>`] and records the attempt in the audit log.
+    pub fn try_cap(&self) -> Result<Cap<P>, CapSecError> {
+        let entry = LogEntry {
+            timestamp: Instant::now(),
+            permission: std::any::type_name::<P>(),
+            granted: true,
+        };
+        let mut log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        log.push(entry);
+        Ok(Cap::new())
+    }
+
+    /// Advisory check — always returns `true`.
+    pub fn is_active(&self) -> bool {
+        true
+    }
+
+    /// Returns a cloned snapshot of the audit log.
+    pub fn entries(&self) -> Vec<LogEntry> {
+        let log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        log.clone()
+    }
+
+    /// Returns the number of entries in the audit log.
+    pub fn entry_count(&self) -> usize {
+        let log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        log.len()
+    }
+}
+
+impl<P: Permission> Clone for LoggedSendCap<P> {
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: PhantomData,
+            log: Arc::clone(&self.log),
+        }
+    }
+}
+
+// ============================================================================
+// DualKeyCap<P>
+// ============================================================================
+
+/// A dual-authorization capability requiring two independent approvals.
+///
+/// Created via [`DualKeyCap::new`], which consumes a [`Cap<P>`] and returns
+/// a `(DualKeyCap<P>, ApproverA, ApproverB)` triple. Both approvers must call
+/// [`approve()`](ApproverA::approve) before [`try_cap()`](DualKeyCap::try_cap)
+/// will succeed.
+///
+/// Implements Saltzer & Schroeder's Separation of Privilege principle:
+/// no single entity can exercise the capability alone.
+///
+/// `!Send + !Sync` by default — use [`make_send`](DualKeyCap::make_send) for
+/// cross-thread transfer. Cloning shares the same approval state.
+pub struct DualKeyCap<P: Permission> {
+    _phantom: PhantomData<P>,
+    _not_send: PhantomData<*const ()>,
+    approvals: Arc<AtomicU8>,
+}
+
+impl<P: Permission> DualKeyCap<P> {
+    /// Creates a dual-authorization capability by consuming a [`Cap<P>`].
+    ///
+    /// Returns a `(DualKeyCap<P>, ApproverA, ApproverB)` triple. Distribute
+    /// the approver handles to separate subsystems to enforce separation of
+    /// privilege.
+    pub fn new(_cap: Cap<P>) -> (Self, ApproverA, ApproverB) {
+        let approvals = Arc::new(AtomicU8::new(0));
+        let cap = Self {
+            _phantom: PhantomData,
+            _not_send: PhantomData,
+            approvals: Arc::clone(&approvals),
+        };
+        let a = ApproverA {
+            approvals: Arc::clone(&approvals),
+        };
+        let b = ApproverB { approvals };
+        (cap, a, b)
+    }
+
+    /// Attempts to obtain a [`Cap<P>`] from this dual-authorization capability.
+    ///
+    /// Returns `Ok(Cap<P>)` if both approvers have called [`approve()`](ApproverA::approve),
+    /// or `Err(CapSecError::InsufficientApprovals)` if not.
+    pub fn try_cap(&self) -> Result<Cap<P>, CapSecError> {
+        if self.approvals.load(Ordering::Acquire) == 3 {
+            Ok(Cap::new())
+        } else {
+            Err(CapSecError::InsufficientApprovals)
+        }
+    }
+
+    /// Advisory check — returns `true` if both approvals have been granted.
+    pub fn is_active(&self) -> bool {
+        self.approvals.load(Ordering::Acquire) == 3
+    }
+
+    /// Converts this capability into a [`DualKeySendCap`] that can cross thread boundaries.
+    pub fn make_send(self) -> DualKeySendCap<P> {
+        DualKeySendCap {
+            _phantom: PhantomData,
+            approvals: self.approvals,
+        }
+    }
+}
+
+impl<P: Permission> Clone for DualKeyCap<P> {
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: PhantomData,
+            _not_send: PhantomData,
+            approvals: Arc::clone(&self.approvals),
+        }
+    }
+}
+
+// ============================================================================
+// DualKeySendCap<P>
+// ============================================================================
+
+/// A thread-safe dual-authorization capability token.
+///
+/// Created via [`DualKeyCap::make_send`]. Unlike [`DualKeyCap`], this implements
+/// `Send + Sync`.
+pub struct DualKeySendCap<P: Permission> {
+    _phantom: PhantomData<P>,
+    approvals: Arc<AtomicU8>,
+}
+
+// SAFETY: DualKeySendCap is explicitly opted into cross-thread transfer via make_send().
+// The inner Arc<AtomicU8> is already Send+Sync.
+unsafe impl<P: Permission> Send for DualKeySendCap<P> {}
+unsafe impl<P: Permission> Sync for DualKeySendCap<P> {}
+
+impl<P: Permission> DualKeySendCap<P> {
+    /// Attempts to obtain a [`Cap<P>`] from this dual-authorization capability.
+    pub fn try_cap(&self) -> Result<Cap<P>, CapSecError> {
+        if self.approvals.load(Ordering::Acquire) == 3 {
+            Ok(Cap::new())
+        } else {
+            Err(CapSecError::InsufficientApprovals)
+        }
+    }
+
+    /// Advisory check — returns `true` if both approvals have been granted.
+    pub fn is_active(&self) -> bool {
+        self.approvals.load(Ordering::Acquire) == 3
+    }
+}
+
+impl<P: Permission> Clone for DualKeySendCap<P> {
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: PhantomData,
+            approvals: Arc::clone(&self.approvals),
+        }
+    }
+}
+
+// ============================================================================
+// ApproverA / ApproverB
+// ============================================================================
+
+/// First approval handle for a [`DualKeyCap`].
+///
+/// `Send + Sync` so it can be passed to another thread or subsystem.
+/// **Not `Clone`** — each approver handle is unique to enforce separation
+/// of privilege. Distribute `ApproverA` and `ApproverB` to different
+/// principals.
+pub struct ApproverA {
+    approvals: Arc<AtomicU8>,
+}
+
+impl ApproverA {
+    /// Records approval from the first authority. Idempotent.
+    pub fn approve(&self) {
+        self.approvals.fetch_or(0b01, Ordering::Release);
+    }
+
+    /// Returns `true` if this approver has already approved.
+    pub fn is_approved(&self) -> bool {
+        self.approvals.load(Ordering::Acquire) & 0b01 != 0
+    }
+}
+
+/// Second approval handle for a [`DualKeyCap`].
+///
+/// `Send + Sync` so it can be passed to another thread or subsystem.
+/// **Not `Clone`** — each approver handle is unique to enforce separation
+/// of privilege.
+pub struct ApproverB {
+    approvals: Arc<AtomicU8>,
+}
+
+impl ApproverB {
+    /// Records approval from the second authority. Idempotent.
+    pub fn approve(&self) {
+        self.approvals.fetch_or(0b10, Ordering::Release);
+    }
+
+    /// Returns `true` if this approver has already approved.
+    pub fn is_approved(&self) -> bool {
+        self.approvals.load(Ordering::Acquire) & 0b10 != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permission::FsRead;
+    use std::mem::size_of;
+
+    // ====== LoggedCap tests ======
+
+    #[test]
+    fn logged_cap_try_cap_succeeds() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        assert!(lcap.try_cap().is_ok());
+    }
+
+    #[test]
+    fn logged_cap_records_entry() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        let _ = lcap.try_cap();
+        let entries = lcap.entries();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].permission.contains("FsRead"));
+        assert!(entries[0].granted);
+    }
+
+    #[test]
+    fn logged_cap_multiple_entries() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        let _ = lcap.try_cap();
+        let _ = lcap.try_cap();
+        let _ = lcap.try_cap();
+        assert_eq!(lcap.entry_count(), 3);
+    }
+
+    #[test]
+    fn logged_cap_entries_snapshot() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        let _ = lcap.try_cap();
+        let snapshot = lcap.entries();
+        let _ = lcap.try_cap();
+        // Snapshot should still have 1 entry, live log has 2
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(lcap.entry_count(), 2);
+    }
+
+    #[test]
+    fn logged_send_cap_crosses_threads() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        let send_cap = lcap.make_send();
+
+        std::thread::spawn(move || {
+            assert!(send_cap.try_cap().is_ok());
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn cloned_logged_cap_shares_log() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        let lcap2 = lcap.clone();
+
+        let _ = lcap.try_cap();
+        let _ = lcap2.try_cap();
+
+        assert_eq!(lcap.entry_count(), 2);
+        assert_eq!(lcap2.entry_count(), 2);
+    }
+
+    #[test]
+    fn logged_cap_is_small() {
+        assert!(size_of::<LoggedCap<FsRead>>() <= 2 * size_of::<usize>());
+    }
+
+    #[test]
+    fn logged_cap_entry_has_correct_permission_name() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let lcap = LoggedCap::new(cap);
+        let _ = lcap.try_cap();
+        let entries = lcap.entries();
+        assert!(entries[0].permission.contains("FsRead"));
+    }
+
+    // ====== DualKeyCap tests ======
+
+    #[test]
+    fn dual_key_try_cap_fails_without_approvals() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, _a, _b) = DualKeyCap::new(cap);
+        assert!(matches!(
+            dcap.try_cap(),
+            Err(CapSecError::InsufficientApprovals)
+        ));
+    }
+
+    #[test]
+    fn dual_key_try_cap_fails_with_one_approval() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, _b) = DualKeyCap::new(cap);
+        a.approve();
+        assert!(matches!(
+            dcap.try_cap(),
+            Err(CapSecError::InsufficientApprovals)
+        ));
+    }
+
+    #[test]
+    fn dual_key_try_cap_succeeds_with_both_approvals() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, b) = DualKeyCap::new(cap);
+        a.approve();
+        b.approve();
+        assert!(dcap.try_cap().is_ok());
+    }
+
+    #[test]
+    fn dual_key_approval_order_irrelevant() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, b) = DualKeyCap::new(cap);
+        b.approve();
+        a.approve();
+        assert!(dcap.try_cap().is_ok());
+    }
+
+    #[test]
+    fn dual_key_approve_is_idempotent() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, _b) = DualKeyCap::new(cap);
+        a.approve();
+        a.approve(); // should not panic
+        // Still needs B
+        assert!(matches!(
+            dcap.try_cap(),
+            Err(CapSecError::InsufficientApprovals)
+        ));
+    }
+
+    #[test]
+    fn dual_key_approvers_are_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ApproverA>();
+        assert_send_sync::<ApproverB>();
+    }
+
+    #[test]
+    fn dual_key_send_cap_crosses_threads() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, b) = DualKeyCap::new(cap);
+        a.approve();
+        b.approve();
+        let send_cap = dcap.make_send();
+
+        std::thread::spawn(move || {
+            assert!(send_cap.try_cap().is_ok());
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn dual_key_approval_crosses_threads() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, b) = DualKeyCap::new(cap);
+
+        a.approve();
+
+        std::thread::spawn(move || {
+            b.approve();
+        })
+        .join()
+        .unwrap();
+
+        assert!(dcap.try_cap().is_ok());
+    }
+
+    #[test]
+    fn cloned_dual_key_shares_approval() {
+        let root = crate::root::test_root();
+        let cap = root.grant::<FsRead>();
+        let (dcap, a, b) = DualKeyCap::new(cap);
+        let dcap2 = dcap.clone();
+
+        a.approve();
+        b.approve();
+
+        assert!(dcap.try_cap().is_ok());
+        assert!(dcap2.try_cap().is_ok());
+    }
+
+    #[test]
+    fn dual_key_cap_is_small() {
+        assert!(size_of::<DualKeyCap<FsRead>>() <= 2 * size_of::<usize>());
+    }
+}

--- a/crates/capsec-tests/tests/type_system.rs
+++ b/crates/capsec-tests/tests/type_system.rs
@@ -578,6 +578,83 @@ fn runtime_cap_with_subsumption() {
     needs_fs_read(&cap); // FsAll subsumes FsRead
 }
 
+// ============================================================================
+// N. PRESCRIPT CAPS (LoggedCap, DualKeyCap)
+// ============================================================================
+
+#[test]
+fn logged_cap_try_cap_returns_valid_cap_for_capsec_std() {
+    use capsec_core::prescript::LoggedCap;
+
+    let root = test_root();
+    let cap = root.grant::<FsRead>();
+    let lcap = LoggedCap::new(cap);
+
+    let cap = lcap.try_cap().expect("should be active");
+    let result = capsec_std::fs::read("/dev/null", &cap);
+    assert!(
+        result.is_ok(),
+        "try_cap() → Cap<P> should work with capsec-std"
+    );
+}
+
+#[test]
+fn logged_cap_records_io_attempt() {
+    use capsec_core::prescript::LoggedCap;
+
+    let root = test_root();
+    let cap = root.grant::<FsRead>();
+    let lcap = LoggedCap::new(cap);
+
+    let cap = lcap.try_cap().expect("should be active");
+    let _ = capsec_std::fs::read("/dev/null", &cap);
+    assert_eq!(lcap.entry_count(), 1);
+}
+
+#[test]
+fn dual_key_cap_try_cap_returns_valid_cap() {
+    use capsec_core::prescript::DualKeyCap;
+
+    let root = test_root();
+    let cap = root.grant::<FsRead>();
+    let (dcap, a, b) = DualKeyCap::new(cap);
+    a.approve();
+    b.approve();
+
+    let cap = dcap.try_cap().expect("should be active");
+    fn needs_fs(_: &impl Has<FsRead>) {}
+    needs_fs(&cap);
+}
+
+#[test]
+fn dual_key_without_approval_prevents_io() {
+    use capsec_core::error::CapSecError;
+    use capsec_core::prescript::DualKeyCap;
+
+    let root = test_root();
+    let cap = root.grant::<FsRead>();
+    let (dcap, _a, _b) = DualKeyCap::new(cap);
+    assert!(matches!(
+        dcap.try_cap(),
+        Err(CapSecError::InsufficientApprovals)
+    ));
+}
+
+#[test]
+fn dual_key_with_subsumption() {
+    use capsec_core::prescript::DualKeyCap;
+
+    let root = test_root();
+    let cap = root.grant::<FsAll>();
+    let (dcap, a, b) = DualKeyCap::new(cap);
+    a.approve();
+    b.approve();
+
+    let cap = dcap.try_cap().expect("should be active");
+    fn needs_fs_read(_: &impl Has<FsRead>) {}
+    needs_fs_read(&cap); // FsAll subsumes FsRead
+}
+
 /// A malicious Has<FsRead> impl that loops forever instead of returning a Cap.
 ///
 /// Cannot be tested directly (would hang the test runner), but the behavior is

--- a/crates/capsec/examples/audit_trail.rs
+++ b/crates/capsec/examples/audit_trail.rs
@@ -1,0 +1,51 @@
+//! Example: Audited capability access with LoggedCap
+//!
+//! Demonstrates how LoggedCap records every capability exercise attempt
+//! in an append-only audit log. Implements Saltzer & Schroeder's
+//! "compromise recording" design principle.
+
+use capsec::prelude::*;
+
+#[capsec::main]
+fn main(root: CapRoot) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Grant FsRead and wrap in a LoggedCap for audit trail
+    let logged_cap = LoggedCap::new(root.fs_read());
+
+    println!("=== Audited Capability Access ===");
+    println!("[start] Log entries: {}", logged_cap.entry_count());
+
+    // 2. Exercise the capability — each try_cap() is logged
+    let cap = logged_cap.try_cap()?;
+    let data = capsec::fs::read("/dev/null", &cap)?;
+    println!("[read] Read {} bytes from /dev/null", data.len());
+
+    // 3. Exercise again
+    let cap = logged_cap.try_cap()?;
+    let _ = capsec::fs::read("/dev/null", &cap)?;
+    println!("[read] Read /dev/null again");
+
+    // 4. Inspect the audit log
+    println!("\n=== Audit Log ({} entries) ===", logged_cap.entry_count());
+    for (i, entry) in logged_cap.entries().iter().enumerate() {
+        println!(
+            "  [{}] permission={}, granted={}, elapsed={:?}",
+            i,
+            entry.permission,
+            entry.granted,
+            entry.timestamp.elapsed()
+        );
+    }
+
+    // 5. Clone shares the same log
+    let clone = logged_cap.clone();
+    let _ = clone.try_cap()?;
+    println!(
+        "\n[clone] After clone exercise: {} total entries (shared log)",
+        logged_cap.entry_count()
+    );
+
+    println!("\n=== Demo Complete ===");
+    println!("Every capability exercise is recorded for compliance.");
+
+    Ok(())
+}

--- a/crates/capsec/examples/dual_authorization.rs
+++ b/crates/capsec/examples/dual_authorization.rs
@@ -1,0 +1,61 @@
+//! Example: Two-person authorization with DualKeyCap
+//!
+//! Demonstrates Saltzer & Schroeder's "separation of privilege" principle:
+//! a capability that requires two independent approvals before it can be
+//! exercised. No single entity can unlock the capability alone.
+
+use capsec::prelude::*;
+
+#[capsec::main]
+fn main(root: CapRoot) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Grant FsWrite and wrap in a DualKeyCap
+    let (dual_cap, approver_a, approver_b) = DualKeyCap::new(root.fs_write());
+
+    println!("=== Dual-Key Authorization ===");
+
+    // 2. Before any approvals: try_cap() fails
+    match dual_cap.try_cap() {
+        Ok(_) => println!("[pre] This should not happen"),
+        Err(e) => println!("[pre] No approvals yet: {e}"),
+    }
+
+    // 3. First approval (e.g., from a manager)
+    approver_a.approve();
+    println!("\n[approve] Approver A approved (manager)");
+    println!(
+        "[status] A approved: {}, B approved: {}",
+        approver_a.is_approved(),
+        approver_b.is_approved()
+    );
+
+    // Still fails — need both
+    match dual_cap.try_cap() {
+        Ok(_) => println!("[partial] This should not happen"),
+        Err(e) => println!("[partial] Only one approval: {e}"),
+    }
+
+    // 4. Second approval (e.g., from security officer)
+    approver_b.approve();
+    println!("\n[approve] Approver B approved (security officer)");
+    println!(
+        "[status] A approved: {}, B approved: {}",
+        approver_a.is_approved(),
+        approver_b.is_approved()
+    );
+
+    // 5. Now try_cap() succeeds
+    let cap = dual_cap.try_cap()?;
+    println!("\n[granted] Dual-key authorization complete!");
+
+    let path = std::env::temp_dir().join("capsec-dual-auth-demo.txt");
+    capsec::fs::write(&path, "authorized write", &cap)?;
+    println!("[write] Wrote to {}", path.display());
+
+    // Clean up
+    std::fs::remove_file(&path).ok();
+
+    println!("\n=== Demo Complete ===");
+    println!("Both authorities approved before write access was granted.");
+
+    Ok(())
+}

--- a/crates/capsec/src/lib.rs
+++ b/crates/capsec/src/lib.rs
@@ -46,6 +46,10 @@ pub use capsec_core::attenuate::{Attenuated, DirScope, HostScope, Scope};
 
 pub use capsec_core::runtime::{Revoker, RuntimeCap, RuntimeSendCap, TimedCap, TimedSendCap};
 
+pub use capsec_core::prescript::{
+    ApproverA, ApproverB, DualKeyCap, DualKeySendCap, LogEntry, LoggedCap, LoggedSendCap,
+};
+
 /// Creates a `CapRoot` and passes it to the given closure.
 ///
 /// This is a convenience entry point. Panics if `root()` has already been called.
@@ -116,8 +120,8 @@ pub mod tokio {
 /// ```
 pub mod prelude {
     pub use crate::{
-        Ambient, Attenuated, Cap, CapRoot, CapSecError, DirScope, EnvRead, EnvWrite, FsAll, FsRead,
-        FsWrite, Has, HostScope, NetAll, NetBind, NetConnect, Permission, Revoker, RuntimeCap,
-        Spawn, Subsumes, TimedCap,
+        Ambient, ApproverA, ApproverB, Attenuated, Cap, CapRoot, CapSecError, DirScope, DualKeyCap,
+        EnvRead, EnvWrite, FsAll, FsRead, FsWrite, Has, HostScope, LoggedCap, NetAll, NetBind,
+        NetConnect, Permission, Revoker, RuntimeCap, Spawn, Subsumes, TimedCap,
     };
 }

--- a/crates/capsec/tests/compile_fail/dual_key_cap_is_not_send.rs
+++ b/crates/capsec/tests/compile_fail/dual_key_cap_is_not_send.rs
@@ -1,0 +1,8 @@
+/// DualKeyCap<P> is !Send — use make_send() for cross-thread transfer.
+use capsec::prelude::*;
+
+fn assert_send<T: Send>() {}
+
+fn main() {
+    assert_send::<DualKeyCap<FsRead>>();
+}

--- a/crates/capsec/tests/compile_fail/dual_key_cap_is_not_send.stderr
+++ b/crates/capsec/tests/compile_fail/dual_key_cap_is_not_send.stderr
@@ -1,0 +1,22 @@
+error[E0277]: `*const ()` cannot be sent between threads safely
+ --> tests/compile_fail/dual_key_cap_is_not_send.rs:7:19
+  |
+7 |     assert_send::<DualKeyCap<FsRead>>();
+  |                   ^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
+  |
+  = help: within `capsec::DualKeyCap<capsec::FsRead>`, the trait `Send` is not implemented for `*const ()`
+note: required because it appears within the type `PhantomData<*const ()>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: PointeeSized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `capsec::DualKeyCap<capsec::FsRead>`
+ --> $WORKSPACE/crates/capsec-core/src/prescript.rs
+  |
+  | pub struct DualKeyCap<P: Permission> {
+  |            ^^^^^^^^^^
+note: required by a bound in `assert_send`
+ --> tests/compile_fail/dual_key_cap_is_not_send.rs:4:19
+  |
+4 | fn assert_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `assert_send`

--- a/crates/capsec/tests/compile_fail/logged_cap_is_not_send.rs
+++ b/crates/capsec/tests/compile_fail/logged_cap_is_not_send.rs
@@ -1,0 +1,8 @@
+/// LoggedCap<P> is !Send — use make_send() for cross-thread transfer.
+use capsec::prelude::*;
+
+fn assert_send<T: Send>() {}
+
+fn main() {
+    assert_send::<LoggedCap<FsRead>>();
+}

--- a/crates/capsec/tests/compile_fail/logged_cap_is_not_send.stderr
+++ b/crates/capsec/tests/compile_fail/logged_cap_is_not_send.stderr
@@ -1,0 +1,22 @@
+error[E0277]: `*const ()` cannot be sent between threads safely
+ --> tests/compile_fail/logged_cap_is_not_send.rs:7:19
+  |
+7 |     assert_send::<LoggedCap<FsRead>>();
+  |                   ^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
+  |
+  = help: within `capsec::LoggedCap<capsec::FsRead>`, the trait `Send` is not implemented for `*const ()`
+note: required because it appears within the type `PhantomData<*const ()>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: PointeeSized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `capsec::LoggedCap<capsec::FsRead>`
+ --> $WORKSPACE/crates/capsec-core/src/prescript.rs
+  |
+  | pub struct LoggedCap<P: Permission> {
+  |            ^^^^^^^^^
+note: required by a bound in `assert_send`
+ --> tests/compile_fail/logged_cap_is_not_send.rs:4:19
+  |
+4 | fn assert_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `assert_send`


### PR DESCRIPTION
Primarily following from these papers:

**Saltzer & Schroeder (1975)**, specifically two design principles:

LoggedCap implements Design Principle #8: Compromise Recording — "mechanisms that reliably record that a compromise of information has occurred can be used in place of more elaborate mechanisms that completely prevent loss." The paper notes that "many computer systems record the date and time of the most recent use of each file. If this record is tamperproof and reported to the owner, it may help discover unauthorized use." `LoggedCap` does this — append-only, tamper-resistant (no `clear()` or `remove()` methods), records timestamp + permission + outcome for every exercise.

`DualKeyCap` implements Design Principle #5: Separation of Privilege — "a protection mechanism that requires two keys to unlock it is more robust and flexible than one that allows access to the presenter of only a single key." The paper gives the nuclear launch example: "two different people both give the correct command." ApproverA and ApproverB being `!Clone` move-only handles enforces that once distributed, no single holder can approve both sides.

Both types also implement the paper's prescript concept (Section II.C.4) — "a rule that must be followed before access to an object is permitted, thereby introducing an opportunity for human judgment." The paper lists five prescript actions: (1) no action, (2) audit trail logging, (3) cooling-off delay, (4) buddy system approval, (5) external authorization signal. LoggedCap is prescript #2, DualKeyCap is prescript #4.

Secondary connections:
* Dennis & Van Horn (1966): The try_cap() interposition pattern mirrors their supervisor-mediated capability exercise — all capability operations pass through a validation gate before granting access. `Cap::new()` being pub(crate) is the software analog of their hardware-enforced capability creation.
* Melicher et al. (2017): The `!Has<P>` design on both types preserves Wyvern's non-transitive authority property — holding a `LoggedCap<FsRead>` does not give you the same authority as holding a `Cap<FsRead>`, because you must  go through the fallible `try_cap()` gate. This is the "caretaker" pattern from the object-capability literature that Melicher formalizes.